### PR TITLE
[FIX] Jenkinsfile IRSA 적용 및 IaC 레포 커밋 로직 개선

### DIFF
--- a/Helm/jenkins/Jenkinsfile
+++ b/Helm/jenkins/Jenkinsfile
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: jenkins-kaniko
 spec:
+  serviceAccountName: jenkins
   containers:
   - name: jnlp  # ✅ 커스텀 에이전트 (Dockerfile.agent 기반)
     image: 572390531726.dkr.ecr.ap-northeast-2.amazonaws.com/woorepie/jenkins:agent-v1.0.2
@@ -21,18 +22,10 @@ spec:
     command: ['sleep']
     args: ['infinity']
     volumeMounts:
-      - name: docker-config
-        mountPath: /kaniko/.docker
       - name: workspace-volume
         mountPath: /home/jenkins/agent
 
   volumes:
-  - name: docker-config
-    secret:
-      secretName: ecr-creds  # ECR 인증 시크릿
-      items:
-        - key: .dockerconfigjson
-          path: config.json
   - name: workspace-volume
     emptyDir: {}
 """
@@ -108,7 +101,7 @@ spec:
             }
         }
 
-        stage('Update Helm Values') {  // ✅ ArgoCD 연동 활성화
+        stage('Update Helm Values') { // ✅ 변경사항 있을 때만 커밋/푸시
             steps {
                 container('jnlp') {
                     withCredentials([usernamePassword(
@@ -117,24 +110,24 @@ spec:
                         passwordVariable: 'GIT_TOKEN'
                     )]) {
                         sh """
-                            # IaC 레포지토리 클론
                             git clone ${INFRA_REPO}
                             cd woorepie-IaC
-                            git checkout feat/helm/#10-helm
+                            git checkout helm
 
                             # values.yaml 업데이트
                             sed -i "s|tag: .*|tag: ${env.IMAGE_TAG}|g" Helm/was/values.yaml
 
-                            # 변경사항 푸시
-                            git config user.name "Jenkins"
-                            git config user.email "jenkins@woorepie.site"
-                            
-                            # 인증 정보 포함된 remote로 변경
-                            git remote set-url origin https://$GIT_USER:$GIT_TOKEN@github.com/woorepie/woorepie-IaC.git
-
                             git add Helm/was/values.yaml
-                            git commit -m "🔧edit: Update WAS image tag to ${env.IMAGE_TAG}"
-                            git push origin feat/helm/#10-helm
+
+                            if ! git diff --cached --exit-code --quiet; then
+                              git config user.name "Jenkins"
+                              git config user.email "jenkins@woorepie.site"
+                              git remote set-url origin https://$GIT_USER:$GIT_TOKEN@github.com/woorepie/woorepie-IaC.git
+                              git commit -m "🔧edit: Update WAS image tag to ${env.IMAGE_TAG}"
+                              git push origin helm
+                            else
+                              echo "No changes to commit."
+                            fi
                         """
                     }
                 }


### PR DESCRIPTION
## ✨ 작업 개요
- Jenkinsfile에서 ECR 인증 방식을 기존 secret(docker config) 기반에서 IRSA(ServiceAccount 권한) 기반으로 전환
- Helm values.yaml 파일의 이미지 태그 변경이 실제로 있을 때만 IaC 레포에 커밋/푸시가 일어나도록 커밋 로직을 개선

## ✅ 작업 목록
- [x] Jenkinsfile에서 ECR 인증 관련 secret 제거
- [x] serviceAccountName을 명시하여 IRSA 기반 권한 적용
- [x] Helm values.yaml 태그 변경 감지 시에만 커밋/푸시 로직 분기
  - 불필요한 커밋/푸시 방지로 파이프라인 안정성 개선


## 📎 관련 이슈
- #19